### PR TITLE
feat: add IchigoLLM (python + api)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,5 +155,6 @@ vq_stoks/
 concatenated_dataset/
 .gradio/
 test/
+cache/
 speech.wav
 transcript.txt

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can also access the API documentation at `http://localhost:8000/docs`
 
 ## LLMs
 
+### Python Usage
 ```python
 # Quick one-liner for audio processing
 from ichigo.llm import process_audio
@@ -86,7 +87,28 @@ response = process_audio("path/to/audio.wav")
 from ichigo.llm import IchigoAssistant
 assistant = IchigoAssistant()
 response = assistant.generate_audio(
-    audio_dict,
+    "path/to/audio.wav",
     max_new_tokens=2048
 )
 ```
+
+### API
+
+```bash
+# Start the API server
+uvicorn ichigo.llm.server:app --host 0.0.0.0 --port 8001
+
+# Use with curl
+curl -X POST "http://localhost:8001/chat/" \
+  -H "accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@path/to/audio.wav"
+
+# With custom max_new_tokens
+curl -X POST "http://localhost:8001/process/?max_new_tokens=1024" \
+  -H "accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@path/to/audio.wav"
+```
+
+You can also access the API documentation at `http://localhost:8001/docs`

--- a/README.md
+++ b/README.md
@@ -6,29 +6,30 @@
 python -m build
 pip install dist/ichigo-0.0.1-py3-none-any.whl
 python -c "import ichigo.asr as asr; print(asr.__file__)" 
+python -c "from ichigo.llm import process_audio; response = process_audio('speech.wav'); print(response)"
 python -c "from ichigo.asr import transcribe; results = transcribe('speech.wav'); print(results)"
 python -c "from ichigo.asr import transcribe; results = transcribe('speech.wav', return_stoks=True); print(results)"
 python -c "from ichigo.asr import transcribe; results = transcribe('/root/ichigo-experiments/test'); print(results)"
 -->
 
-Setup package with `python=3.10`
+1. Setup package with `python=3.10` (dev)
 
 ```
 python -m build
 python -m twine upload dist/* 
-
-# test
-python -c "import ichigo.asr as asr; print(asr.__file__)"
 ```
 
-### Batch Processing
-1. Install python package
+2. Install python package
 
 ```bash
 pip install ichigo
 ```
 
-2. Transcribe with your audio file
+## ASR
+
+### Batch Processing
+
+1. Transcribe with your audio file
 
 ```python
 # Quick one-liner
@@ -72,3 +73,20 @@ curl -X POST "http://localhost:8000/transcribe/?return_stoks=true" \
 ```
 
 You can also access the API documentation at `http://localhost:8000/docs`
+
+
+## LLMs
+
+```python
+# Quick one-liner for audio processing
+from ichigo.llm import process_audio
+response = process_audio("path/to/audio.wav")
+
+# Or with more control using the assistant class
+from ichigo.llm import IchigoAssistant
+assistant = IchigoAssistant()
+response = assistant.generate_audio(
+    audio_dict,
+    max_new_tokens=2048
+)
+```

--- a/ichigo/llm/__init__.py
+++ b/ichigo/llm/__init__.py
@@ -1,0 +1,27 @@
+import torchaudio
+
+from ichigo.llm.ichigo import IchigoAssistant
+
+_default_assistant = None
+
+
+def get_assistant(**kwargs) -> IchigoAssistant:
+    """Get or create default voice assistant instance"""
+    global _default_assistant
+    if _default_assistant is None:
+        _default_assistant = IchigoAssistant(**kwargs)
+    return _default_assistant
+
+
+def process_audio(audio_path, max_new_tokens: int = 2048, **kwargs) -> str:
+    """Quick audio processing function using default assistant"""
+    assistant = get_assistant(**kwargs)
+
+    wav, sr = torchaudio.load(audio_path)
+
+    if sr != 16000:
+        wav = torchaudio.functional.resample(wav, sr, 16000)
+
+    audio_dict = {"array": wav, "sampling_rate": sr}
+
+    return assistant.generate_audio(audio_dict, max_new_tokens=max_new_tokens)

--- a/ichigo/llm/__init__.py
+++ b/ichigo/llm/__init__.py
@@ -1,5 +1,3 @@
-import torchaudio
-
 from ichigo.llm.ichigo import IchigoAssistant
 
 _default_assistant = None
@@ -13,15 +11,7 @@ def get_assistant(**kwargs) -> IchigoAssistant:
     return _default_assistant
 
 
-def process_audio(audio_path, max_new_tokens: int = 2048, **kwargs) -> str:
+def process_audio(audio_input, max_new_tokens: int = 2048, **kwargs) -> str:
     """Quick audio processing function using default assistant"""
     assistant = get_assistant(**kwargs)
-
-    wav, sr = torchaudio.load(audio_path)
-
-    if sr != 16000:
-        wav = torchaudio.functional.resample(wav, sr, 16000)
-
-    audio_dict = {"array": wav, "sampling_rate": sr}
-
-    return assistant.generate_audio(audio_dict, max_new_tokens=max_new_tokens)
+    return assistant.generate_audio(audio_input, max_new_tokens=max_new_tokens)

--- a/ichigo/llm/base.py
+++ b/ichigo/llm/base.py
@@ -1,0 +1,28 @@
+import torch
+import time
+
+
+class VoiceAssistant:
+    @torch.no_grad()
+    def generate_audio(
+        self,
+        audio,
+        max_new_tokens=2048,
+    ):
+        raise NotImplementedError
+
+    @torch.no_grad()
+    def generate_text(
+        self,
+        text,
+    ):
+        raise NotImplementedError
+
+    @torch.no_grad()
+    def generate_ttft(
+        self,
+        audio,
+    ):
+        tmp = time.perf_counter()
+        self.generate_audio(audio, max_new_tokens=1)
+        return time.perf_counter() - tmp

--- a/ichigo/llm/ichigo.py
+++ b/ichigo/llm/ichigo.py
@@ -1,0 +1,74 @@
+import os
+import warnings
+
+warnings.filterwarnings(
+    "ignore", category=FutureWarning, module="vector_quantize_pytorch"
+)
+warnings.filterwarnings("ignore", category=FutureWarning, module="whisper")
+warnings.filterwarnings(
+    "ignore", category=FutureWarning, message="You are using `torch.load`"
+)
+
+import torch
+from huggingface_hub import hf_hub_download
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+from whisperspeech.vq_stoks import RQBottleneckTransformer
+
+from .base import VoiceAssistant
+
+
+class IchigoAssistant(VoiceAssistant):
+    def __init__(self):
+        device = "cuda"
+
+        if not os.path.exists("./cache/whisper-vq-stoks-v3-7lang.model"):
+            hf_hub_download(
+                repo_id="WhisperSpeech/WhisperSpeech",
+                filename="whisper-vq-stoks-v3-7lang.model",
+                local_dir="./cache/",
+            )
+        self.vq_model = RQBottleneckTransformer.load_model(
+            "./cache/whisper-vq-stoks-v3-7lang.model"
+        ).to(device)
+        self.vq_model.ensure_whisper(device)
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            "homebrewltd/Ichigo-llama3.1-s-instruct-v0.4", cache_dir="./cache"
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            "homebrewltd/Ichigo-llama3.1-s-instruct-v0.4",
+            device_map="cuda",
+            torch_dtype=torch.bfloat16,
+            cache_dir="./cache",
+        )
+
+        self.pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+
+    def audio_to_sound_tokens(self, wav, sr, device="cuda"):
+        with torch.no_grad():
+            codes = self.vq_model.encode_audio(wav.to(device))
+            codes = codes[0].cpu().tolist()
+
+        result = "".join(f"<|sound_{num:04d}|>" for num in codes)
+        return f"<|sound_start|>{result}<|sound_end|>"
+
+    def generate_audio(
+        self,
+        audio,
+        max_new_tokens=2048,
+    ):
+        sound_tokens = self.audio_to_sound_tokens(
+            audio["array"].unsqueeze(0), audio["sampling_rate"]
+        )
+
+        messages = [
+            {"role": "user", "content": sound_tokens},
+        ]
+
+        generation_args = {
+            "max_new_tokens": max_new_tokens,
+            "return_full_text": False,
+        }
+
+        output = self.pipe(messages, **generation_args)
+        return output[0]["generated_text"]

--- a/ichigo/llm/server.py
+++ b/ichigo/llm/server.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+
+from ichigo.llm import process_audio
+
+app = FastAPI(
+    title="Ichigo LLM API",
+    description="API for audio processing using Ichigo LLM",
+    version="0.0.1",
+)
+
+
+@app.post("/chat/")
+async def process_audio_file(
+    file: UploadFile = File(...),
+    max_new_tokens: int = 2048,
+):
+    """
+    Process an audio file uploaded via HTTP POST request
+
+    Args:
+        file: Audio file to process
+        max_new_tokens: Maximum number of tokens to generate
+    """
+    if not file.filename.lower().endswith((".wav", ".mp3", ".flac")):
+        raise HTTPException(400, "Unsupported file format")
+
+    with tempfile.NamedTemporaryFile(
+        delete=False, suffix=Path(file.filename).suffix
+    ) as tmp:
+        content = await file.read()
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        response = process_audio(tmp_path, max_new_tokens=max_new_tokens)
+        return JSONResponse(content={"response": response})
+
+    except Exception as e:
+        raise HTTPException(500, str(e))
+
+    finally:
+        os.unlink(tmp_path)
+
+
+@app.get("/")
+async def root():
+    return {
+        "message": "Welcome to Ichigo LLM API. Send POST requests to /process/ endpoint."
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,27 +14,17 @@ requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["asr", "llm", "tts", "ichigo"]
 dependencies = [
-    "datasets==3.1.0",
     "huggingface_hub==0.26.2",
-    "lightning==2.4.0",
     "openai_whisper==20240930",
     "torch==2.5.1",
     "torchaudio==2.5.1",
     "vector_quantize_pytorch==1.6.22",
-    "webdataset==0.2.85",
-    "wandb>=0.12.10",
-    "librosa",
-    "soundfile",
-    "black",
-    "evaluate",
     "transformers",
-    "jiwer",
-    "gradio",
-    "matplotlib",
-    "seaborn",
     "build",
     "twine",
     "fastapi",
+    "whisperspeech",
+    "accelerate>=0.26.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## LLMs

### Python Usage
```python
# Quick one-liner for audio processing
from ichigo.llm import process_audio
response = process_audio("path/to/audio.wav")

# Or with more control using the assistant class
from ichigo.llm import IchigoAssistant
assistant = IchigoAssistant()
response = assistant.generate_audio(
    "path/to/audio.wav",
    max_new_tokens=2048
)
```

### API

```bash
# Start the API server
uvicorn ichigo.llm.server:app --host 0.0.0.0 --port 8001

# Use with curl
curl -X POST "http://localhost:8001/chat/" \
  -H "accept: application/json" \
  -H "Content-Type: multipart/form-data" \
  -F "file=@path/to/audio.wav"

# With custom max_new_tokens
curl -X POST "http://localhost:8001/process/?max_new_tokens=1024" \
  -H "accept: application/json" \
  -H "Content-Type: multipart/form-data" \
  -F "file=@path/to/audio.wav"
```

You can also access the API documentation at `http://localhost:8001/docs`